### PR TITLE
CAF-2562: Custom user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ You can generate a default keystore setting both the keystore password and key p
 
 `keytool -genkey -alias tomcat -keystore .keystore -keyalg RSA`
 
-Generating a custom keystore with your own password/alias/protocol is not currently supported. For more information on generating keystores see these [instructions](https://tomcat.apache.org/tomcat-7.0-doc/ssl-howto.html).
+For more information on generating keystores see these [instructions](https://tomcat.apache.org/tomcat-7.0-doc/ssl-howto.html).
+
+If you have generated the keystore with custom keystore pass, alias or key pass, you must set the environment variables described below.
 
 Place this keystore file in a folder called `keystore` in job-service-deploy. Name it `.keystore` or else provide your own custom path by setting `JOB_SERVICE_KEYSTORE` (e.g. `./mykeystore/ks.p12`).
 

--- a/README.md
+++ b/README.md
@@ -222,4 +222,15 @@ Additional override parameters can be set and their function is described below.
     <td>./keystore/.keystore</td>
     <td>If you are activating the HTTPS port, you can override the default keystore location to provide your own keystore as a volume. This is the path of the keystore file (i.e. `./mykeystore/ks.p12`).</td>
   </tr>
+  <tr>
+    <td>JOB_SERVICE_KEYSTOREPASS</td>
+    <td>changeit</td>
+    <td>If you generated your keystore with a custom keystorepass, use this environment variable to update the Job Service's keystore configuration in the `server.xml`</td>
+  </tr>
+  <tr>
+    <td>JOB_SERVICE_KEYSTORE_ALIAS</td>
+    <td>tomcat</td>
+    <td>If you generated your keystore with a custom keystore alias, use this environment variable to update the Job Service's keystore configuration in the `server.xml`</td>
+  </tr>
+</table>
 </table>

--- a/README.md
+++ b/README.md
@@ -225,7 +225,12 @@ Additional override parameters can be set and their function is described below.
   <tr>
     <td>JOB_SERVICE_KEYSTOREPASS</td>
     <td>changeit</td>
-    <td>If you generated your keystore with a custom keystorepass, use this environment variable to update the Job Service's keystore configuration in the `server.xml`</td>
+    <td>Set this environment variable to the keystore pass set when creating the keystore. The default assumes you have set the default "changeit" pass when creating the keystore.</td>
+  </tr>
+  <tr>
+    <td>JOB_SERVICE_KEY_PASS</td>
+    <td>changeit</td>
+    <td>Set this environment variable to the key pass set when creating the keystore, which may be different from the keystore pass. The default is "changeit".</td>
   </tr>
   <tr>
     <td>JOB_SERVICE_KEYSTORE_ALIAS</td>
@@ -233,4 +238,4 @@ Additional override parameters can be set and their function is described below.
     <td>If you generated your keystore with a custom keystore alias, use this environment variable to update the Job Service's keystore configuration in the `server.xml`</td>
   </tr>
 </table>
-</table>
+

--- a/docker-compose.https.yml
+++ b/docker-compose.https.yml
@@ -3,6 +3,8 @@ services:
   jobservice:
     environment:
       SSL_TOMCAT_CA_CERT_LOCATION: /keystore/tomcat.keystore
+      SSL_TOMCAT_CA_CERT_KEYSTOREPASS: ${JOB_SERVICE_KEYSTOREPASS:-changeit}
+      SSL_TOMCAT_CA_CERT_KEYSTORE_ALIAS: ${JOB_SERVICE_KEYSTORE_ALIAS:-tomcat}
     volumes:
       - ${JOB_SERVICE_KEYSTORE:-./keystore/.keystore}:/keystore/tomcat.keystore
     ports:

--- a/docker-compose.https.yml
+++ b/docker-compose.https.yml
@@ -4,7 +4,7 @@ services:
     environment:
       SSL_TOMCAT_CA_CERT_LOCATION: /keystore/tomcat.keystore
       SSL_TOMCAT_CA_CERT_KEYSTOREPASS: ${JOB_SERVICE_KEYSTOREPASS:-changeit}
-      SSL_TOMCAT_CA_CERT_KEY_PASS: ${JOB_SERVICE_KEY_PASS:-changeit}
+      SSL_TOMCAT_CA_CERT_KEY_PASS: ${JOB_SERVICE_KEY_PASS:-${JOB_SERVICE_KEYSTOREPASS}}
       SSL_TOMCAT_CA_CERT_KEYSTORE_ALIAS: ${JOB_SERVICE_KEYSTORE_ALIAS:-tomcat}
     volumes:
       - ${JOB_SERVICE_KEYSTORE:-./keystore/.keystore}:/keystore/tomcat.keystore

--- a/docker-compose.https.yml
+++ b/docker-compose.https.yml
@@ -4,6 +4,7 @@ services:
     environment:
       SSL_TOMCAT_CA_CERT_LOCATION: /keystore/tomcat.keystore
       SSL_TOMCAT_CA_CERT_KEYSTOREPASS: ${JOB_SERVICE_KEYSTOREPASS:-changeit}
+      SSL_TOMCAT_CA_CERT_KEY_PASS: ${JOB_SERVICE_KEY_PASS:-changeit}
       SSL_TOMCAT_CA_CERT_KEYSTORE_ALIAS: ${JOB_SERVICE_KEYSTORE_ALIAS:-tomcat}
     volumes:
       - ${JOB_SERVICE_KEYSTORE:-./keystore/.keystore}:/keystore/tomcat.keystore

--- a/docker-compose.https.yml
+++ b/docker-compose.https.yml
@@ -3,8 +3,8 @@ services:
   jobservice:
     environment:
       SSL_TOMCAT_CA_CERT_LOCATION: /keystore/tomcat.keystore
-      SSL_TOMCAT_CA_CERT_KEYSTOREPASS: ${JOB_SERVICE_KEYSTOREPASS:-changeit}
-      SSL_TOMCAT_CA_CERT_KEY_PASS: ${JOB_SERVICE_KEY_PASS:-${JOB_SERVICE_KEYSTOREPASS}}
+      SSL_TOMCAT_CA_CERT_KEYSTORE_PASS: ${JOB_SERVICE_KEYSTORE_PASS:-changeit}
+      SSL_TOMCAT_CA_CERT_KEY_PASS: ${JOB_SERVICE_KEY_PASS:-changeit}
       SSL_TOMCAT_CA_CERT_KEYSTORE_ALIAS: ${JOB_SERVICE_KEYSTORE_ALIAS:-tomcat}
     volumes:
       - ${JOB_SERVICE_KEYSTORE:-./keystore/.keystore}:/keystore/tomcat.keystore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       CAF_STATUS_CHECK_TIME: 5
       CAF_TRACKING_PIPE: jobtracking-in
       CAF_WEBSERVICE_URL: http://jobservice:8080/job-service/v1
-    image: jobservice/job-service:2.0.0
+    image: rh7-artifactory.svs.hpeswlab.net:8443/caf/job-service:2.1.0-SNAPSHOT
     ports:
       - "${JOB_SERVICE_PORT:-9411}:8080"
 


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-2562

These changes allow users to provide environment variables which change the values of fields in the connector of the tomcat server.xml.

The Keystorepass seems to be required when creating a keystore, and if none is given to the java keytool it defaults to changeit.

The Key pass is another password which seems to be required, and if you don't set it, it defaults to be the same as the Keystorepass.

The key alias seems to be another required field. The user generating the keystore will need to provide one, and set this environment variable if they don't set it to "tomcat".