### PR TITLE
CAF-2691: Users provide their own server.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,4 +222,24 @@ Additional override parameters can be set and their function is described below.
     <td>./keystore/.keystore</td>
     <td>If you are activating the HTTPS port, you can override the default keystore location to provide your own keystore as a volume. This is the path of the keystore file (i.e. `./mykeystore/ks.p12`).</td>
   </tr>
+
+#### Providing your own server.xml
+
+You can provide your own server.xml by running the `docker-compose.serverxml.yml` override.
+
+`docker-compose -f docker-compose.yml -f docker-compose.https.yml -f docker-compose.serverxml.yml up`
+
+You must set the following environment variable with the location of the server.xml you want to provide:
+
+<table>
+  <tr>
+    <th>Environment Variable</th>
+    <th>Default</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>JOB_SERVICE_SERVER_XML</td>
+    <td>no default</td>
+    <td>This is the relative path of the server.xml you want to provide, i.e. `./server.xml`</td>
+  </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Additional override parameters can be set and their function is described below.
     <td>./keystore/.keystore</td>
     <td>If you are activating the HTTPS port, you can override the default keystore location to provide your own keystore as a volume. This is the path of the keystore file (i.e. `./mykeystore/ks.p12`).</td>
   </tr>
+</table>
 
 #### Providing your own server.xml
 

--- a/README.md
+++ b/README.md
@@ -226,11 +226,11 @@ Additional override parameters can be set and their function is described below.
 
 #### Providing your own server.xml
 
-You can provide your own server.xml by running the `docker-compose.serverxml.yml` override.
+You can provide your own server.xml in the same job-service-deploy directory by running the `docker-compose.serverxml.yml` override.
 
 `docker-compose -f docker-compose.yml -f docker-compose.https.yml -f docker-compose.serverxml.yml up`
 
-You must set the following environment variable with the location of the server.xml you want to provide:
+You can use a different path by setting the following environment variable to the location of the server.xml you want to provide:
 
 <table>
   <tr>
@@ -240,7 +240,7 @@ You must set the following environment variable with the location of the server.
   </tr>
   <tr>
     <td>JOB_SERVICE_SERVER_XML</td>
-    <td>no default</td>
-    <td>This is the relative path of the server.xml you want to provide, i.e. `./server.xml`</td>
+    <td>./server.xml</td>
+    <td>This is the relative path of the server.xml you want to provide.</td>
   </tr>
 </table>

--- a/docker-compose.serverxml.yml
+++ b/docker-compose.serverxml.yml
@@ -1,0 +1,5 @@
+version: '3'
+services:
+  jobservice:
+    volumes:
+      - ${JOB_SERVICE_SERVER_XML}:/usr/local/tomcat/conf/server.xml

--- a/docker-compose.serverxml.yml
+++ b/docker-compose.serverxml.yml
@@ -2,4 +2,4 @@ version: '3'
 services:
   jobservice:
     volumes:
-      - ${JOB_SERVICE_SERVER_XML}:/usr/local/tomcat/conf/server.xml
+      - ${JOB_SERVICE_SERVER_XML:-./server.xml}:/usr/local/tomcat/conf/server.xml


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-2691

These changes allow users to supply their own server.xml file.

It is mounted as a volume and overwrites the existing default tomcat server.xml.

Users just need to run the override file and supply the environment variable `JOB_SERVICE_SERVER_XML` specifying the location of the provided server.xml.